### PR TITLE
Fix Ollama init bug

### DIFF
--- a/deepseek-eng.py
+++ b/deepseek-eng.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import List, Dict, Any, Optional
 from openai import OpenAI
+import httpx
 import requests
 from pydantic import BaseModel
 from dotenv import load_dotenv
@@ -87,7 +88,10 @@ def initialize_client():
             console.print("[bold yellow]Invalid choice, defaulting to first model.[/bold yellow]")
             chosen_model = models[0]
 
-        client = OpenAI(base_url=f"{base_url}/v1", api_key="ollama")
+        # Explicitly disable proxy usage to avoid compatibility issues with
+        # older httpx versions that don't support the parameter.
+        http_client = httpx.Client(proxies=None)
+        client = OpenAI(base_url=f"{base_url}/v1", api_key="ollama", http_client=http_client)
     else:
         api_key = os.getenv("DEEPSEEK_API_KEY")
         if not api_key:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-openai
-pydantic
-python-dotenv
-rich
-prompt_toolkit
-requests
+openai>=1.58.1
+pydantic>=2.10.4
+python-dotenv>=1.0.1
+rich>=13.9.4
+prompt_toolkit>=3.0.50
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- disable proxies when connecting to Ollama
- pin dependency versions

## Testing
- `python3 -m py_compile deepseek-eng.py`

------
https://chatgpt.com/codex/tasks/task_e_685fce39ff9c832db33f91bdb38dd6f8