### PR TITLE
Fix httpx client initialization for Ollama

### DIFF
--- a/deepseek-eng.py
+++ b/deepseek-eng.py
@@ -88,9 +88,9 @@ def initialize_client():
             console.print("[bold yellow]Invalid choice, defaulting to first model.[/bold yellow]")
             chosen_model = models[0]
 
-        # Explicitly disable proxy usage to avoid compatibility issues with
-        # older httpx versions that don't support the parameter.
-        http_client = httpx.Client(proxies=None)
+        # Explicitly disable proxy usage. Using ``trust_env=False`` works
+        # across httpx versions without triggering unsupported arguments.
+        http_client = httpx.Client(trust_env=False)
         client = OpenAI(base_url=f"{base_url}/v1", api_key="ollama", http_client=http_client)
     else:
         api_key = os.getenv("DEEPSEEK_API_KEY")


### PR DESCRIPTION
## Summary
- handle older httpx versions by switching to `trust_env=False` when creating the Ollama `httpx.Client`

## Testing
- `python -m py_compile deepseek-eng.py`


------
https://chatgpt.com/codex/tasks/task_e_685fd1205d48832d8468b51b3817ccae